### PR TITLE
Implement entitlement with minor refactorings

### DIFF
--- a/doc/Todo.zhcn.md
+++ b/doc/Todo.zhcn.md
@@ -10,20 +10,26 @@
 项目基础的构建，包括里程碑、功能分区、源码结构、构建工具、测试覆盖率和代码规范检查等。
 
 - 项目配置
-	- [ ] 里程碑定义：定义项目里程碑和迭代计划
-	- [ ] 功能分区定义：定义项目功能分区
-	- [ ] 权限管理：定义项目访问权限
+	- [x] 创建Github组织
+	- [ ] 创建Github团队
+	- [x] 创建Github项目看板
+	- [x] 创建Github仓库
+	- [x] 创建Github标签
+	- [x] 创建Github里程碑
+	- [ ] 配置Github访问权限
 
 - 项目构建
 	- [x] 源码结构：定义项目结构
 	- [ ] 构建工具：集成构建工具并定义可共享的Build配置
 	- [ ] 包发布：发布项目包
 
-- 工程优化
-	- [ ] 持续集成（CI）：配置CI流水线
-	- [ ] 持续发布（CD）：配置CD流水线
-	- [ ] 代码规范检查：集成代码规范检查工具
-	- [ ] 测试覆盖率：集成测试覆盖率工具
+- 工程自动化
+	- [x] 项目构建（CI）
+	- [ ] 代码规范检查（CI）
+	- [x] 单元测试（CI）
+	- [ ] 测试覆盖率（CI）
+	- [ ] 安全检查（CI）
+	- [ ] 持续发布（CD）
 
 ## 架构设计、技术栈与基础设施
 
@@ -34,51 +40,60 @@
   - [ ] 时序图
 
 - 核心模块和接口设计
-  - [x] Eligible
-  - [ ] Balance
-  - [ ] Expiry
+  - [ ] Eligible
+  - [ ] Balance & Expiry
   - [ ] Entitlement
   - [ ] Chain
   - [ ] Taxonomy
 
-- 技术栈与工具
+- 基础设施、技术栈与工具链
   - 文档创作
 	- [x] 文本：Markdown
 	- [x] 图形：DrawIO
   - 程序开发
     - [x] 编程语言：C#，.NET 8.0+
 	- [x] 开发环境：Visual Studio 2022, Visual Studio Code
-	- [ ] 代码库管理：Github
+	- [x] 代码库管理：Github
   - 外部库
 	- [x] 单元测试：xUnit
 	- [x] 时间日期处理：NodaTime
 	- [x] 命令行解析：CommandLineParser
 	- [x] 命令行交互：Spectre.Console
 
-## 运行时（内核）
+## 工程项目
 
-- Tier 0
-  - [x] IEligible接口
-  - [x] IEligible扩展方法
-  - [x] Delegation类
-  - [x] Eligible单元测试
-
-- Tier 1
-  - Balance
-    - [x] IBalance接口
-    - [x] BalanceType枚举
-    - [x] IBalance扩展方法
-    - [x] Balance类
-    - [x] Balance单元测试
-  - Expiry
-    - [x] IExpiry接口
-    - [x] IExpiry扩展方法
-    - [x] Expiry类
-    - [x] Expiry单元测试
-
-- Tier 2
-  - [ ] Entitlement对象
-  - [ ] Chain对象
+- Perkify.Core（运行时，内核）
+	- Tier 0
+	  - [x] IEligible接口
+	  - [x] IEligible扩展方法
+	  - [x] Delegation类
+	  - [x] Eligible单元测试
+	- Tier 1
+	  - Balance
+		- [x] IBalance接口
+		- [x] BalanceType枚举
+		- [x] IBalance扩展方法
+		- [ ] IBalance单元测试
+		- [x] Balance类
+		- [x] Balance单元测试
+	  - Expiry
+		- [x] Renewal类
+		- [ ] Renewal单元测试
+		- [x] IExpiry接口
+		- [x] IExpiry扩展方法
+		- [ ] IExpiry单元测试
+		- [x] Expiry类
+		- [x] Expiry单元测试
+	- Tier 2
+	  - Entitlement
+		- [ ] Entitlement类
+		- [ ] Entitlement单元测试
+	  - Chain
+		- [ ] Chain类
+		- [ ] Chain单元测试
+	  - Taxonomy
+		- [ ] Taxonomy类
+		- [ ] Taxonomy单元测试
 
 ## 文档和演示代码
 

--- a/src/Perkify.Core.Tests/BalanceTests.cs
+++ b/src/Perkify.Core.Tests/BalanceTests.cs
@@ -219,7 +219,7 @@ namespace Perkify.Core.UnitTests
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
 
-            balance.Spend(spend, overspending: true);
+            balance.Deduct(spend, overspending: true);
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(expected, balance.Outgoing);
         }
@@ -236,7 +236,7 @@ namespace Perkify.Core.UnitTests
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => balance.Spend(spend, overspending));
+            Assert.Throws<ArgumentOutOfRangeException>(() => balance.Deduct(spend, overspending));
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
         }
@@ -254,7 +254,7 @@ namespace Perkify.Core.UnitTests
             Assert.Equal(outgoing, balance.Outgoing);
             Assert.False(balance.IsEligible);
 
-            Assert.Throws<InvalidOperationException>(() => balance.Spend(spend, overspending));
+            Assert.Throws<InvalidOperationException>(() => balance.Deduct(spend, overspending));
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
             Assert.Equal(expected, balance.GetOverSpendingAmount());
@@ -270,7 +270,7 @@ namespace Perkify.Core.UnitTests
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => balance.Spend(spend, false));
+            Assert.Throws<ArgumentOutOfRangeException>(() => balance.Deduct(spend, false));
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
         }
@@ -285,7 +285,7 @@ namespace Perkify.Core.UnitTests
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
 
-            Assert.Throws<OverflowException>(() => balance.Spend(spend, overspending: true));
+            Assert.Throws<OverflowException>(() => balance.Deduct(spend, overspending: true));
             Assert.Equal(incoming, balance.Incoming);
             Assert.Equal(outgoing, balance.Outgoing);
         }

--- a/src/Perkify.Core/Balance.cs
+++ b/src/Perkify.Core/Balance.cs
@@ -88,7 +88,7 @@
         /// <param name="overspending">The flag to allow over-spending the balance</param>
         /// <returns>The balance after spending the amount.</returns></returns>
         /// <exception cref="ArgumentOutOfRangeException">Raised when the amount is less than 0 or overspending.</exception>
-        public Balance Spend(long delta, bool overspending = true)
+        public Balance Deduct(long delta, bool overspending = true)
         {
             if (delta < 0)
             {

--- a/src/Perkify.Core/Chain.cs
+++ b/src/Perkify.Core/Chain.cs
@@ -1,30 +1,12 @@
 ﻿namespace Perkify.Core
 {
-    public enum ChainType
-    {
-        Any,
-        All,
-    }
-
     public class Chain : IEligible
     {
-        private readonly ChainType chainType;
-
         private IList<Entitlement> entitlements = new List<Entitlement>();
-
-        public Chain(ChainType chainType)
-        {
-            this.chainType = chainType;
-        }
 
         #region Implement IEligible interface
 
-        public bool IsEligible => this.chainType switch
-        {
-            ChainType.All => entitlements.All(entitlement => entitlement.IsEligible),
-            ChainType.Any => entitlements.Any(entitlement => entitlement.IsEligible),
-            _ => throw new InvalidOperationException(),
-        };
+        public bool IsEligible => entitlements.Any(entitlement => entitlement.IsEligible);
 
         #endregion
     }

--- a/src/Perkify.Core/Entitlement.cs
+++ b/src/Perkify.Core/Entitlement.cs
@@ -1,14 +1,47 @@
 ﻿namespace Perkify.Core
 {
-    public class Entitlement : IEligible, IBalance<Entitlement>
+    [Flags]
+    public enum AutoRenewalMode
     {
-        private readonly Balance? balance;
+        None = 0x0000,
+        Topup = 0x0001,
+        Deduct = 0x0002,
+        Adjust = 0x0004,
+        Default = Topup | Deduct
+    }
 
-        private readonly Expiry? expiry;
+    public class Entitlement : IEligible, IBalance<Entitlement>, INowUtc, IExpiry<Entitlement>
+    {
+        private readonly AutoRenewalMode mode;
 
-        private readonly IEligible? prerequesite;
+        private Expiry? expiry;
 
-        private readonly Renewal? renewal;
+        private Balance? balance;
+
+        private IEligible? prerequesite;
+
+        public Entitlement(AutoRenewalMode mode = AutoRenewalMode.Default)
+        {
+            this.mode = mode;
+        }
+
+        public Entitlement WithBalance(Balance balance)
+        {
+            this.balance = balance;
+            return this;
+        }
+
+        public Entitlement WithExpiry(Expiry expiry)
+        {
+            this.expiry = expiry;
+            return this;
+        }
+
+        public Entitlement WithPrerequesite(IEligible prerequesite)
+        {
+            this.prerequesite = prerequesite;
+            return this;
+        }
 
         #region Implements IEligible interface
 
@@ -30,20 +63,124 @@
         public Entitlement Topup(long delta)
         {
             this.balance?.Topup(delta);
+            if(this.mode.HasFlag(AutoRenewalMode.Topup))
+            {
+                this.expiry?.Renew();
+            }
             return this;
         }
 
-        public Entitlement Spend(long delta, bool overspending = true)
+        public Entitlement Deduct(long delta, bool overspending = true)
         {
-            this.balance?.Spend(delta, overspending);
+            this.balance?.Deduct(delta, overspending);
+            if(this.mode.HasFlag(AutoRenewalMode.Deduct))
+            {
+                this.expiry?.Renew();
+            }
             return this;
         }
 
         public Entitlement Adjust(long? incoming, long? outgoing)
         {
             this.balance?.Adjust(incoming, outgoing);
+            if (this.mode.HasFlag(AutoRenewalMode.Adjust))
+            {
+                this.expiry?.Renew();
+            }
             return this;
         }
+
+        #endregion
+
+        #region Implements INowUtc interface
+
+        public DateTime NowUtc => this.expiry?.NowUtc ?? DateTime.UtcNow;
+
+        #endregion
+
+        #region Implements IExpiry<T> interface
+
+        #region Remaining & Overdue
+
+        /// <summary>The Grace period as absolute time span.</summary>
+        public TimeSpan GracePeriod => this.expiry?.GracePeriod ?? TimeSpan.Zero;
+
+        /// <summary>
+        /// The remaining portion.
+        /// - If suspended, the remaining portion is the time between suspend time and expiry time.
+        /// - If eligible, the remaining portion is the current time between now and expiry time.
+        /// - If ineligible (after grace period), the remaining portion is negative grace period.
+        /// </summary>
+        public TimeSpan Remaining => this.expiry?.Remaining ?? TimeSpan.MaxValue;
+
+        /// <summary>
+        /// The overdue portion.
+        /// - Suspended: The overdue portion is the time between suspend time and expiry time. Zero if suspend time is earlier than expiry time.
+        /// - Eligible: The overdue portion is the time between expiry time and now. Zero if now is earlier than expiry time.
+        /// - Ineligible (after grace period): The overdue portion is the grace period.
+        /// </summary>
+        public TimeSpan Overdue => this.expiry?.Overdue ?? TimeSpan.Zero;
+
+        #endregion
+
+        #region Renew
+
+        /// <summary>The expiry time in UTC.</summary>
+        public DateTime ExpiryUtc => this.expiry?.ExpiryUtc ?? DateTime.MaxValue;
+
+        /// <summary>The renewal period based on ISO8601 duration string and flag to identify calendar arithmetic.</summary>
+        public Renewal? Renewal => this.expiry?.Renewal;
+
+        /// <summary>Renew the expiry time in timeline arithmetic or calendrical arithmetic.</summary>
+        /// <param name="renewal">The renewal period based on ISO8601 duration string and flag to identify calendar arithmetic.</param>
+        /// <returns>The expiry time after renewal.</returns>
+        public Entitlement Renew(Renewal? renewal)
+        {
+            this.expiry?.Renew(renewal);
+            return this;
+        }
+
+        #endregion
+
+        #region Deactivate & Activate
+
+        /// <summary>
+        /// The suspend time in UTC.
+        /// - Explicit suspension time (smaller or equals to deadline time) if any suspension is applied.
+        /// - Implicit suspension time (equals to deadline time) when the expiry time is ineligible.
+        /// - Null when the expiry time is eligible (and no suspension is applied).
+        /// </summary>
+        public DateTime? SuspensionUtc => this.expiry?.SuspensionUtc;
+
+        /// <summary>
+        /// Boolean flag to identify if the expiry time is active.
+        /// - True if the expiry time is deactivated (suspended).
+        /// - False if the expiry time is activated (not suspended).
+        /// </summary>
+        public bool IsActive => this.expiry?.IsActive ?? true;
+
+        /// <summary>Deactivate the expiry time.</summary>
+        /// <param name="suspendUtc">The suspension time in UTC.</param>
+        /// <returns>The expiry time after suspension.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The suspension time must be earlier than current time.</exception>
+        public Entitlement Deactivate(DateTime? suspensionUtc = null)
+        {
+            this.expiry?.Deactivate(suspensionUtc);
+            return this;
+        }
+
+        /// <summary>Activate the expiry time.</summary>
+        /// <param name="resumptionUtc">The resumption time in UTC.</param>
+        /// <param name="extended">Boolean flag to extend the expiry time after resumption.</param>
+        /// <returns>The expiry time after resumption.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Resume time must be greater than suspend time.</exception>
+        public Entitlement Activate(DateTime? resumptionUtc = null, bool extended = false)
+        {
+            this.expiry?.Activate(resumptionUtc, extended);
+            return this;
+        }
+
+        #endregion
 
         #endregion
     }

--- a/src/Perkify.Core/Expiry.cs
+++ b/src/Perkify.Core/Expiry.cs
@@ -1,7 +1,6 @@
 ﻿namespace Perkify.Core
 {
     using NodaTime;
-    using NodaTime.Text;
 
     /// <summary>Expiry time for eligibility.</summary>
     public class Expiry : INowUtc, IEligible, IExpiry<Expiry>
@@ -15,6 +14,7 @@
             clock ??= SystemClock.Instance;
             this.ExpiryUtc = expiryUtc ?? clock.GetCurrentInstant().ToDateTimeUtc();
             this.GracePeriod = grace ?? TimeSpan.Zero;
+            this.Renewal = null;
             this.clock = clock;
             this.suspensionUtc = null;
         }
@@ -37,6 +37,15 @@
             }
 
             this.suspensionUtc = suspensionUtc < this.GetDeadlineUtc() ? suspensionUtc : this.GetDeadlineUtc();
+            return this;
+        }
+
+        /// <summary>Specify the renewal period.</summary>
+        /// <param name="renewal">The renewal period based on ISO8601 duration string and flag to identify calendar arithmetic.</param>
+        /// <returns>The expiry time with specified renewal period.</returns>
+        public Expiry WithRenewal(Renewal renewal)
+        {
+            this.Renewal = renewal;
             return this;
         }
 
@@ -111,7 +120,7 @@
         public DateTime ExpiryUtc { get; private set; }
 
         /// <summary>The renewal period based on ISO8601 duration string and flag to identify calendar arithmetic.</summary>
-        public Renewal Renewal { get; private set; }
+        public Renewal? Renewal { get; private set; }
 
         /// <summary>
         /// Renew the expiry time in timeline arithmetic or calendrical arithmetic.

--- a/src/Perkify.Core/IBalance.cs
+++ b/src/Perkify.Core/IBalance.cs
@@ -47,7 +47,7 @@
         /// <param name="overspending">The flag to allow over-spending the balance</param>
         /// <returns>The balance after spending the amount.</returns></returns>
         /// <exception cref="ArgumentOutOfRangeException">Raised when the amount is less than 0 or overspending.</exception>
-        public T Spend(long delta, bool overspending = true);
+        public T Deduct(long delta, bool overspending = true);
 
         /// <summary>
         /// Adjust the balance with incoming and outgoing amounts.

--- a/src/Perkify.Core/IExpiry.cs
+++ b/src/Perkify.Core/IExpiry.cs
@@ -3,7 +3,7 @@
     /// <summary>The interface to maintain an expiry time with grace period for eligibility.</summary>
     public interface IExpiry<T> where T: IExpiry<T>, INowUtc
     {
-        #region IsExpired, Remaining & Overdue
+        #region Remaining & Overdue
 
         /// <summary>The Grace period as absolute time span.</summary>
         public TimeSpan GracePeriod { get; }
@@ -32,7 +32,7 @@
         public DateTime ExpiryUtc { get; }
 
         /// <summary>The renewal period based on ISO8601 duration string and flag to identify calendar arithmetic.</summary>
-        public Renewal Renewal { get; }
+        public Renewal? Renewal { get; }
 
         /// <summary>Renew the expiry time in timeline arithmetic or calendrical arithmetic.</summary>
         /// <param name="renewal">The renewal period based on ISO8601 duration string and flag to identify calendar arithmetic.</param>


### PR DESCRIPTION
- Simplify entitlement chain framing.
- Rename "spend" to "deduct" in IBalance interface.
- Cleanup unused namespace in Expiry class.